### PR TITLE
my予想ページからmy予想view,予想編集ページから更新画面へ内容が反映されるよう実装しました

### DIFF
--- a/app/Http/Controllers/ForecastController.php
+++ b/app/Http/Controllers/ForecastController.php
@@ -60,7 +60,7 @@ class ForecastController extends Controller
         // $patterns->save();
 
 
-        return redirect("/browse_update");
+        return view("/browse_update",['forecasts' => $forecasts,'courses' => $courses]);
 
 
     }
@@ -86,6 +86,9 @@ class ForecastController extends Controller
         return view('browse');
     }
     
+    
+
+
     public function browse_update() {
         return view('browse_update');
     }
@@ -124,8 +127,13 @@ class ForecastController extends Controller
         $patterns->save();
 
 
-        return redirect("/browse");
+
+
+        return view("/browse",['forecasts' => $forecasts,'courses' => $courses]);
 
 }
+
+
+
 
 }

--- a/public/css/browse.css
+++ b/public/css/browse.css
@@ -11312,6 +11312,10 @@ textarea.form-control-lg {
   margin: 80px 0px 0px 0px;
 }
 
+.left {
+  padding: 20px 20px;
+}
+
 .entry-title {
   margin-left: 10px;
 }
@@ -11345,8 +11349,28 @@ span {
 
 #race-name {
   width: 300px;
+  font-size: 25px;
 }
 
 #race-round {
   width: 40px;
+  font-size: 25px;
+}
+
+.forecast-pattern {
+  font-size: 25px;
+  padding: 15px 15px 15px 15px;
+  margin-bottom: 12px;
+  margin-left: 5px;
+}
+
+.right {
+  margin-top: 25px;
+  padding-right: 20px;
+  padding-left: 40px;
+}
+
+#comment {
+  font-size: 25px;
+  margin-top: 20px;
 }

--- a/resources/sass/browse.scss
+++ b/resources/sass/browse.scss
@@ -48,7 +48,7 @@
 
 .left {
 
-
+    padding: 20px 20px;
 
 }
 
@@ -93,10 +93,38 @@ span {
 
 #race-name {
     width: 300px;
+    font-size: 25px;
 
 }
 
 #race-round {
     width: 40px;
+    font-size: 25px;
+
 
 }
+
+.forecast-pattern {
+    font-size: 25px;
+    padding: 15px 15px 15px 15px;
+    margin-bottom: 12px;
+    margin-left: 5px;
+}
+
+
+
+
+//　main右
+.right {
+    margin-top: 25px;
+    padding-right: 20px;
+    padding-left: 40px;
+
+}
+
+#comment {
+    font-size: 25px;
+    margin-top: 20px;
+
+}
+

--- a/resources/views/browse.blade.php
+++ b/resources/views/browse.blade.php
@@ -20,36 +20,34 @@
                 <div class=" h2 border-bottom fw-bold entry-title">進入予想</div>
                 <div class="entry fw-bold">
                     <div class="entry-cource fw-bold h3">1コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇                
+                    <input id="entry-boat" type="text"value="{{ $courses->course1 }}" placeholder="" />号艇                
                     <div class="entry-cource fw-bold h3">2コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text"value="{{ $courses->course2 }}" placeholder="" />号艇
                     <div class="entry-cource fw-bold h3">3コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text"value="{{ $courses->course3 }}" placeholder="" />号艇
                     <div class="entry-cource fw-bold h3">4コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text" value="{{ $courses->course4 }}"placeholder="" />号艇
                     <div class="entry-cource fw-bold h3">5コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text" value="{{ $courses->course5 }}"placeholder="" />号艇
                     <div class="entry-cource fw-bold h3">6コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text" value="{{ $courses->course6 }}"placeholder="" />号艇
                 </div>
                 <div class="race">
-                    <input id="race-name" type="text" placeholder="会場名" />
-                    <input id="race-round" type="text" placeholder="R" /><span fw-bold>R</span>
+                    <input id="race-name" type="text" value="{{ $forecasts->stadium }}" >
+                    <input id="race-round" type="text" value="{{ $forecasts->race }}"><span fw-bold>R</span>
                 </div>
-                <div class="forecast form-floating">
-                    <textarea class="form-control" style="height: 240px"></textarea>
-                    <label for="floatingTextarea">パターン１</label>                    
+                <div class=" form-floating">
+                    <textarea class="forecast-pattern" style="height: 240px" cols="43" rows="13"></textarea>                   
                 </div>
-                <div class="forecast form-floating">
-                    <textarea class="form-control" style="height: 240px"></textarea>
-                    <label for="floatingTextarea">パターン2</label>                    
+                <div class=" form-floating">
+                    <textarea class="forecast-pattern" style="height: 240px" cols="43" rows="13"></textarea>
                 </div>
         </div>
         {{-- メイン部分右側　コメント --}}
         <div class="right col-5">
             <div class="comment">
                 <div class="comment-logo h2  fw-bold">コメント</div>
-                <textarea name="introduction" id="introduction" cols="41" rows="28" class="form-control"></textarea>
+                <textarea name="comment" id="comment" cols="41" rows="16" class="form-control">{{ $forecasts->comment }}</textarea>
                 <p></p>
             </div>    
         </div>

--- a/resources/views/browse_update.blade.php
+++ b/resources/views/browse_update.blade.php
@@ -20,36 +20,34 @@
                 <div class=" h2 border-bottom fw-bold entry-title">進入予想</div>
                 <div class="entry fw-bold">
                     <div class="entry-cource fw-bold h3">1コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇                
+                    <input id="entry-boat" type="text"value="{{ $courses->course1 }}" placeholder="" />号艇                
                     <div class="entry-cource fw-bold h3">2コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text"value="{{ $courses->course2 }}" placeholder="" />号艇
                     <div class="entry-cource fw-bold h3">3コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text"value="{{ $courses->course3 }}" placeholder="" />号艇
                     <div class="entry-cource fw-bold h3">4コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text" value="{{ $courses->course4 }}"placeholder="" />号艇
                     <div class="entry-cource fw-bold h3">5コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text" value="{{ $courses->course5 }}"placeholder="" />号艇
                     <div class="entry-cource fw-bold h3">6コース</div> 
-                    <input id="entry-boat" type="text" placeholder="" />号艇
+                    <input id="entry-boat" type="text" value="{{ $courses->course6 }}"placeholder="" />号艇
                 </div>
                 <div class="race">
-                    <input id="race-name" type="text" placeholder="会場名" />
-                    <input id="race-round" type="text" placeholder="R" /><span fw-bold>R</span>
+                    <input id="race-name" type="text" value="{{ $forecasts->stadium }}" >
+                    <input id="race-round" type="text" value="{{ $forecasts->race }}"><span fw-bold>R</span>
                 </div>
-                <div class="forecast form-floating">
-                    <textarea class="form-control" style="height: 240px"></textarea>
-                    <label for="floatingTextarea">パターン１</label>                    
+                <div class=" form-floating">
+                    <textarea class="forecast-pattern" style="height: 240px" cols="43" rows="13"></textarea>                   
                 </div>
-                <div class="forecast form-floating">
-                    <textarea class="form-control" style="height: 240px"></textarea>
-                    <label for="floatingTextarea">パターン2</label>                    
+                <div class=" form-floating">
+                    <textarea class="forecast-pattern" style="height: 240px" cols="43" rows="13"></textarea>
                 </div>
         </div>
         {{-- メイン部分右側　コメント --}}
         <div class="right col-5">
             <div class="comment">
                 <div class="comment-logo h2  fw-bold">コメント</div>
-                <textarea name="introduction" id="introduction" cols="41" rows="28" class="form-control"></textarea>
+                <textarea name="comment" id="comment" cols="41" rows="16" class="form-control">{{ $forecasts->comment }}</textarea>
                 <p></p>
             </div>    
         </div>


### PR DESCRIPTION
### 変更内容

・my予想ページからmy予想viewページに予想作成後画面遷移され、
　記事の内容が反映されたページが閲覧できるよう実装しました。

・予想編集画面から更新ボタンで画面遷移され、
　更新内容が反映されたページが閲覧できるよう実装しました。